### PR TITLE
style(throwing-exception): change throwing exception style

### DIFF
--- a/src/Search/Infrastructure/Extensions/BrokerDependencyInjection.cs
+++ b/src/Search/Infrastructure/Extensions/BrokerDependencyInjection.cs
@@ -12,10 +12,8 @@ public static class BrokerDependencyInjection
         {
             var brokerConfig = builder.Configuration.GetSection(BrokerOptions.SectionName)
                                                     .Get<BrokerOptions>();
-            if (brokerConfig is null)
-            {
-                throw new ArgumentNullException(nameof(BrokerOptions));
-            }
+            
+            ArgumentNullException.ThrowIfNull(brokerConfig, nameof(BrokerOptions));
 
             configure.AddConsumers(Assembly.GetExecutingAssembly());
 


### PR DESCRIPTION
## Summary

### Description of Changes

Refactored the null-check for `brokerConfig` in the `BrokerOptions` class from a traditional null-check and exception throw to use the more concise `ArgumentNullException.ThrowIfNull` method.

#### Before:
```csharp
if (brokerConfig is null)
{
    throw new ArgumentNullException(nameof(BrokerOptions));
}